### PR TITLE
chore: add `input_type` param for query/documents embeddings

### DIFF
--- a/aurelio_sdk/client.py
+++ b/aurelio_sdk/client.py
@@ -540,6 +540,7 @@ class AurelioClient:
     def embedding(
         self,
         input: Union[str, List[str]],
+        input_type: Annotated[str, Literal["queries", "documents"]],
         model: Annotated[str, Literal["bm25"]],
         timeout: int = 30,
         retries: int = 3,
@@ -564,7 +565,7 @@ class AurelioClient:
             ApiRateLimitError: If the rate limit is exceeded.
         """
         client_url = f"{self.base_url}/v1/embeddings"
-        data = {"input": input, "model": model}
+        data = {"input": input, "input_type": input_type, "model": model}
 
         for attempt in range(1, retries + 1):
             try:

--- a/aurelio_sdk/client_async.py
+++ b/aurelio_sdk/client_async.py
@@ -696,6 +696,7 @@ class AsyncAurelioClient:
     async def embedding(
         self,
         input: Union[str, List[str]],
+        input_type: Annotated[str, Literal["queries", "documents"]],
         model: Annotated[str, Literal["bm25"]],
         timeout: int = 30,
         retries: int = 3,
@@ -725,7 +726,7 @@ class AsyncAurelioClient:
         # Added retry logic similar to extract_url
         async with aiohttp.ClientSession(timeout=session_timeout) as session:
             for attempt in range(1, retries + 1):
-                data = {"input": input, "model": model}
+                data = {"input": input, "input_type": input_type, "model": model}
                 try:
                     async with session.post(
                         client_url, json=data, headers=self.headers


### PR DESCRIPTION
Allows user to select embedding type:

- `queries`: embeds the query component for the scoring against documents
- `documents` embeds the documents component that are scored against the queries